### PR TITLE
Wrap audio session in a proxy object.

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -315,6 +315,8 @@ if (is_ios || is_mac) {
           "objc/components/audio/RTCAudioSession+Private.h",
           "objc/components/audio/RTCAudioSession.h",
           "objc/components/audio/RTCAudioSession.mm",
+          "objc/components/audio/RTCAudioSessionProxy.h",
+          "objc/components/audio/RTCAudioSessionProxy.m",
           "objc/components/audio/RTCAudioSessionConfiguration.h",
           "objc/components/audio/RTCAudioSessionConfiguration.m",
         ]
@@ -1235,6 +1237,7 @@ if (is_ios || is_mac) {
           "objc/base/RTCVideoRenderer.h",
           "objc/base/RTCYUVPlanarBuffer.h",
           "objc/components/audio/RTCAudioSession.h",
+          "objc/components/audio/RTCAudioSessionProxy.h",
           "objc/components/audio/RTCAudioSessionConfiguration.h",
           "objc/components/capturer/RTCCameraVideoCapturer.h",
           "objc/components/capturer/RTCFileVideoCapturer.h",

--- a/sdk/objc/components/audio/RTCAudioSession.h
+++ b/sdk/objc/components/audio/RTCAudioSession.h
@@ -23,6 +23,7 @@ extern NSInteger const kRTCAudioSessionErrorConfiguration;
 
 @class RTC_OBJC_TYPE(RTCAudioSession);
 @class RTC_OBJC_TYPE(RTCAudioSessionConfiguration);
+@class RTC_OBJC_TYPE(RTCAudioSessionProxy);
 
 // Surfaces AVAudioSession events. WebRTC will listen directly for notifications
 // from AVAudioSession and handle them before calling these delegate methods,
@@ -130,11 +131,11 @@ RTC_OBJC_EXPORT
 RTC_OBJC_EXPORT
 @interface RTC_OBJC_TYPE (RTCAudioSession) : NSObject <RTC_OBJC_TYPE(RTCAudioSessionActivationDelegate)>
 
-/** Convenience property to access the AVAudioSession singleton. Callers should
+/** Convenience property to access the AVAudioSession singleton (session.native). Callers should
  *  not call setters on AVAudioSession directly, but other method invocations
  *  are fine.
  */
-@property(nonatomic, readonly) AVAudioSession *session;
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCAudioSessionProxy) *session;
 
 /** Our best guess at whether the session is active based on results of calls to
  *  AVAudioSession.

--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -20,6 +20,7 @@
 #include "rtc_base/synchronization/mutex.h"
 
 #import "RTCAudioSessionConfiguration.h"
+#import "RTCAudioSessionProxy.h"
 #import "base/RTCLogging.h"
 
 #if !defined(ABSL_HAVE_THREAD_LOCAL)
@@ -47,7 +48,7 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 // lock contention so coarse locks should be fine for now.
 @implementation RTC_OBJC_TYPE (RTCAudioSession) {
   webrtc::Mutex _mutex;
-  AVAudioSession *_session;
+  RTCAudioSessionProxy *_session;
   volatile int _activationCount;
   volatile int _webRTCSessionCount;
   BOOL _isActive;
@@ -72,7 +73,8 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 }
 
 - (instancetype)init {
-  return [self initWithAudioSession:[AVAudioSession sharedInstance]];
+  AVAudioSession *native = [AVAudioSession sharedInstance];
+  return [self initWithAudioSession:[[RTC_OBJC_TYPE(RTCAudioSessionProxy) alloc] initWithAudioSession:native]];
 }
 
 /** This initializer provides a way for unit tests to inject a fake/mock audio session. */
@@ -109,10 +111,10 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
                selector:@selector(handleApplicationDidBecomeActive:)
                    name:UIApplicationDidBecomeActiveNotification
                  object:nil];
-    [_session addObserver:self
-               forKeyPath:kRTCAudioSessionOutputVolumeSelector
-                  options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
-                  context:(__bridge void *)RTC_OBJC_TYPE(RTCAudioSession).class];
+    [_session.native addObserver:self
+                      forKeyPath:kRTCAudioSessionOutputVolumeSelector
+                         options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
+                         context:(__bridge void *)RTC_OBJC_TYPE(RTCAudioSession).class];
 
     RTCLog(@"RTC_OBJC_TYPE(RTCAudioSession) (%p): init.", self);
   }
@@ -121,9 +123,9 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-  [_session removeObserver:self
-                forKeyPath:kRTCAudioSessionOutputVolumeSelector
-                   context:(__bridge void *)RTC_OBJC_TYPE(RTCAudioSession).class];
+  [_session.native removeObserver:self
+                       forKeyPath:kRTCAudioSessionOutputVolumeSelector
+                          context:(__bridge void *)RTC_OBJC_TYPE(RTCAudioSession).class];
   RTCLog(@"RTC_OBJC_TYPE(RTCAudioSession) (%p): dealloc.", self);
 }
 
@@ -365,16 +367,15 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
   // Attempt to activate if we're not active.
   // Attempt to deactivate if we're active and it's the last unbalanced call.
   if (shouldSetActive) {
-    AVAudioSession *session = self.session;
     // AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation is used to ensure
     // that other audio sessions that were interrupted by our session can return
     // to their active state. It is recommended for VoIP apps to use this
     // option.
     AVAudioSessionSetActiveOptions options =
         active ? 0 : AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation;
-    success = [session setActive:active
-                     withOptions:options
-                           error:&error];
+    success = [self.session setActive:active
+                          withOptions:options
+                                error:&error];
     if (outError) {
       *outError = error;
     }
@@ -818,7 +819,7 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 }
 
 - (void)audioSessionDidActivate:(AVAudioSession *)session {
-  if (_session != session) {
+  if (self.session.native != session) {
     RTCLogError(@"audioSessionDidActivate called on different AVAudioSession");
   }
   RTCLog(@"Audio session was externally activated.");
@@ -837,7 +838,7 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 }
 
 - (void)audioSessionDidDeactivate:(AVAudioSession *)session {
-  if (_session != session) {
+  if (self.session.native != session) {
     RTCLogError(@"audioSessionDidDeactivate called on different AVAudioSession");
   }
   RTCLog(@"Audio session was externally deactivated.");
@@ -850,7 +851,7 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
                         change:(NSDictionary *)change
                        context:(void *)context {
   if (context == (__bridge void *)RTC_OBJC_TYPE(RTCAudioSession).class) {
-    if (object == _session) {
+    if (object == _session.native) {
       NSNumber *newVolume = change[NSKeyValueChangeNewKey];
       RTCLog(@"OutputVolumeDidChange to %f", newVolume.floatValue);
       [self notifyDidChangeOutputVolume:newVolume.floatValue];

--- a/sdk/objc/components/audio/RTCAudioSessionProxy.h
+++ b/sdk/objc/components/audio/RTCAudioSessionProxy.h
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2016 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+#import "RTCMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+RTC_OBJC_EXPORT
+@interface RTC_OBJC_TYPE (RTCAudioSessionProxy) : NSObject
+@property(nonatomic, readonly) AVAudioSession *native;
+
+#pragma mark-
+
+@property(copy, nullable) NSError *__nullable (^setActiveBlock)(BOOL active, AVAudioSessionSetActiveOptions options);
+@property(copy, nullable) NSError *__nullable (^setCategoryBlock)(AVAudioSessionCategory category, AVAudioSessionCategoryOptions options);
+@property(copy, nullable) NSError *__nullable (^setModeBlock)(NSString *mode);
+@property(copy, nullable) NSError *__nullable (^setInputGainBlock)(float gain);
+@property(copy, nullable) NSError *__nullable (^setPreferredSampleRateBlock)(double sampleRate);
+@property(copy, nullable) NSError *__nullable (^setPreferredIOBufferDurationBlock)(NSTimeInterval duration);
+@property(copy, nullable) NSError *__nullable (^setPreferredInputNumberOfChannelsBlock)(NSInteger count);
+@property(copy, nullable) NSError *__nullable (^setPreferredOutputNumberOfChannelsBlock)(NSInteger count);
+@property(copy, nullable) NSError *__nullable (^overrideOutputAudioPortBlock)(AVAudioSessionPortOverride portOverride);
+@property(copy, nullable) NSError *__nullable (^setPreferredInputBlock)(AVAudioSessionPortDescription *inPort);
+@property(copy, nullable) NSError *__nullable (^setInputDataSourceBlock)(AVAudioSessionDataSourceDescription *dataSource);
+@property(copy, nullable) NSError *__nullable (^setOutputDataSourceBlock)(AVAudioSessionDataSourceDescription *dataSource);
+
+#pragma mark-
+
+- (instancetype)initWithAudioSession:(AVAudioSession*)audioSession;
+- (instancetype)init NS_UNAVAILABLE;
+
+#pragma mark-
+
+@property(readonly) NSString *category;
+@property(readonly) AVAudioSessionCategoryOptions categoryOptions;
+@property(readonly) NSString *mode;
+@property(readonly) BOOL secondaryAudioShouldBeSilencedHint;
+@property(readonly) AVAudioSessionRouteDescription *currentRoute;
+@property(readonly) NSInteger maximumInputNumberOfChannels;
+@property(readonly) NSInteger maximumOutputNumberOfChannels;
+@property(readonly) float inputGain;
+@property(readonly) BOOL inputGainSettable;
+@property(readonly) BOOL inputAvailable;
+@property(readonly, nullable) NSArray<AVAudioSessionDataSourceDescription *> *inputDataSources;
+@property(readonly, nullable) AVAudioSessionDataSourceDescription *inputDataSource;
+@property(readonly, nullable) NSArray<AVAudioSessionDataSourceDescription *> *outputDataSources;
+@property(readonly, nullable) AVAudioSessionDataSourceDescription *outputDataSource;
+@property(readonly) double sampleRate;
+@property(readonly) double preferredSampleRate;
+@property(readonly) NSInteger inputNumberOfChannels;
+@property(readonly) NSInteger outputNumberOfChannels;
+@property(readonly) float outputVolume;
+@property(readonly) NSTimeInterval inputLatency;
+@property(readonly) NSTimeInterval outputLatency;
+@property(readonly) NSTimeInterval IOBufferDuration;
+@property(readonly) NSTimeInterval preferredIOBufferDuration;
+
+#pragma mark-
+
+- (BOOL)setActive:(BOOL)active withOptions:(AVAudioSessionSetActiveOptions)options error:(NSError **)outError;
+- (BOOL)setCategory:(AVAudioSessionCategory)category
+        withOptions:(AVAudioSessionCategoryOptions)options
+              error:(NSError **)outError;
+- (BOOL)setMode:(NSString *)mode error:(NSError **)outError;
+- (BOOL)setInputGain:(float)gain error:(NSError **)outError;
+- (BOOL)setPreferredSampleRate:(double)sampleRate error:(NSError **)outError;
+- (BOOL)setPreferredIOBufferDuration:(NSTimeInterval)duration
+                               error:(NSError **)outError;
+- (BOOL)setPreferredInputNumberOfChannels:(NSInteger)count
+                                    error:(NSError **)outError;
+- (BOOL)setPreferredOutputNumberOfChannels:(NSInteger)count
+                                     error:(NSError **)outError;
+- (BOOL)overrideOutputAudioPort:(AVAudioSessionPortOverride)portOverride
+                          error:(NSError **)outError;
+- (BOOL)setPreferredInput:(AVAudioSessionPortDescription *)inPort
+                    error:(NSError **)outError;
+- (BOOL)setInputDataSource:(AVAudioSessionDataSourceDescription *)dataSource
+                     error:(NSError **)outError;
+- (BOOL)setOutputDataSource:(AVAudioSessionDataSourceDescription *)dataSource
+                      error:(NSError **)outError;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sdk/objc/components/audio/RTCAudioSessionProxy.m
+++ b/sdk/objc/components/audio/RTCAudioSessionProxy.m
@@ -1,0 +1,283 @@
+/*
+ *  Copyright 2016 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#import "RTCAudioSessionProxy.h"
+#import "base/RTCLogging.h"
+
+@interface RTC_OBJC_TYPE (RTCAudioSessionProxy)()
+@property (nonatomic, strong) AVAudioSession *native;
+@end
+
+@implementation RTC_OBJC_TYPE (RTCAudioSessionProxy)
+
+- (instancetype)init {
+    return [self initWithAudioSession:[AVAudioSession sharedInstance]];
+}
+
+- (instancetype)initWithAudioSession:(AVAudioSession*)audioSession {
+    if (self = [super init]) {
+        _native = audioSession;
+        RTCLog(@"RTC_OBJC_TYPE(RTCAudioSessionProxy) (%p): init.", self);
+    }
+    return self;
+}
+
+- (void)dealloc {
+    RTCLog(@"RTC_OBJC_TYPE(RTCAudioSessionProxy) (%p): dealloc.", self);
+}
+
+#pragma mark -
+
+- (BOOL)setActive:(BOOL)active withOptions:(AVAudioSessionSetActiveOptions)options error:(NSError **)outError
+{
+    if(self.setActiveBlock) {
+        NSError* error = self.setActiveBlock(active, options);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setActive:active withOptions:options error:outError];
+}
+
+- (BOOL)setCategory:(NSString *)category
+        withOptions:(AVAudioSessionCategoryOptions)options
+              error:(NSError **)outError {
+    if(self.setCategoryBlock) {
+        NSError* error = self.setCategoryBlock(category, options);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setCategory:category withOptions:options error:outError];
+}
+
+- (BOOL)setMode:(NSString *)mode error:(NSError **)outError {
+    if(self.setModeBlock) {
+        NSError* error = self.setModeBlock(mode);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setMode:mode error:outError];
+}
+
+- (BOOL)setInputGain:(float)gain error:(NSError **)outError
+{
+    if(self.setInputGainBlock) {
+        NSError* error = self.setInputGainBlock(gain);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setInputGain:gain error:outError];
+}
+
+- (BOOL)setPreferredSampleRate:(double)sampleRate error:(NSError **)outError
+{
+    if(self.setPreferredSampleRateBlock) {
+        NSError* error = self.setPreferredSampleRateBlock(sampleRate);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setPreferredSampleRate:sampleRate error:outError];
+}
+
+- (BOOL)setPreferredIOBufferDuration:(NSTimeInterval)duration
+                               error:(NSError **)outError
+{
+    if(self.setPreferredIOBufferDurationBlock) {
+        NSError* error = self.setPreferredIOBufferDurationBlock(duration);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setPreferredIOBufferDuration:duration error:outError];
+}
+
+- (BOOL)setPreferredInputNumberOfChannels:(NSInteger)count
+                                    error:(NSError **)outError
+{
+    if(self.setPreferredInputNumberOfChannelsBlock) {
+        NSError* error = self.setPreferredInputNumberOfChannelsBlock(count);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setPreferredInputNumberOfChannels:count error:outError];
+}
+
+- (BOOL)setPreferredOutputNumberOfChannels:(NSInteger)count
+                                     error:(NSError **)outError
+{
+    if(self.setPreferredOutputNumberOfChannelsBlock) {
+        NSError* error = self.setPreferredOutputNumberOfChannelsBlock(count);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setPreferredOutputNumberOfChannels:count error:outError];
+}
+
+- (BOOL)overrideOutputAudioPort:(AVAudioSessionPortOverride)portOverride
+                          error:(NSError **)outError
+{
+    if(self.overrideOutputAudioPortBlock) {
+        NSError* error = self.overrideOutputAudioPortBlock(portOverride);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native overrideOutputAudioPort:portOverride error:outError];
+}
+
+- (BOOL)setPreferredInput:(AVAudioSessionPortDescription *)inPort
+                    error:(NSError **)outError
+{
+    if(self.setPreferredInputBlock) {
+        NSError* error = self.setPreferredInputBlock(inPort);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setPreferredInput:inPort error:outError];
+}
+
+- (BOOL)setInputDataSource:(AVAudioSessionDataSourceDescription *)dataSource
+                     error:(NSError **)outError
+{
+    if(self.setInputDataSourceBlock) {
+        NSError* error = self.setInputDataSourceBlock(dataSource);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setInputDataSource:dataSource error:outError];
+}
+
+- (BOOL)setOutputDataSource:(AVAudioSessionDataSourceDescription *)dataSource
+                      error:(NSError **)outError
+{
+    if(self.setOutputDataSourceBlock) {
+        NSError* error = self.setOutputDataSourceBlock(dataSource);
+        if (outError) {
+            *outError = error;
+        }
+        return (error == NULL);
+    }
+    return [self.native setOutputDataSource:dataSource error:outError];
+}
+
+#pragma mark -
+
+- (NSString *)category {
+    return self.native.category;
+}
+
+- (AVAudioSessionCategoryOptions)categoryOptions {
+    return self.native.categoryOptions;
+}
+
+- (NSString *)mode {
+    return self.native.mode;
+}
+
+- (BOOL)secondaryAudioShouldBeSilencedHint {
+    return self.native.secondaryAudioShouldBeSilencedHint;
+}
+
+- (AVAudioSessionRouteDescription *)currentRoute {
+    return self.native.currentRoute;
+}
+
+- (NSInteger)maximumInputNumberOfChannels {
+    return self.native.maximumInputNumberOfChannels;
+}
+
+- (NSInteger)maximumOutputNumberOfChannels {
+    return self.native.maximumOutputNumberOfChannels;
+}
+
+- (float)inputGain {
+    return self.native.inputGain;
+}
+
+- (BOOL)inputGainSettable {
+    return self.native.inputGainSettable;
+}
+
+- (BOOL)inputAvailable {
+    return self.native.inputAvailable;
+}
+
+- (NSArray<AVAudioSessionDataSourceDescription *> *)inputDataSources {
+    return self.native.inputDataSources;
+}
+
+- (AVAudioSessionDataSourceDescription *)inputDataSource {
+    return self.native.inputDataSource;
+}
+
+- (NSArray<AVAudioSessionDataSourceDescription *> *)outputDataSources {
+    return self.native.outputDataSources;
+}
+
+- (AVAudioSessionDataSourceDescription *)outputDataSource {
+    return self.native.outputDataSource;
+}
+
+- (double)sampleRate {
+    return self.native.sampleRate;
+}
+
+- (double)preferredSampleRate {
+    return self.native.preferredSampleRate;
+}
+
+- (NSInteger)inputNumberOfChannels {
+    return self.native.inputNumberOfChannels;
+}
+
+- (NSInteger)outputNumberOfChannels {
+    return self.native.outputNumberOfChannels;
+}
+
+- (float)outputVolume {
+    return self.native.outputVolume;
+}
+
+- (NSTimeInterval)inputLatency {
+    return self.native.inputLatency;
+}
+
+- (NSTimeInterval)outputLatency {
+    return self.native.outputLatency;
+}
+
+- (NSTimeInterval)IOBufferDuration {
+    return self.native.IOBufferDuration;
+}
+
+- (NSTimeInterval)preferredIOBufferDuration {
+    return self.native.preferredIOBufferDuration;
+}
+
+@end

--- a/sdk/objc/unittests/RTCAudioSessionTest.mm
+++ b/sdk/objc/unittests/RTCAudioSessionTest.mm
@@ -19,6 +19,7 @@
 #import "components/audio/RTCAudioSession+Private.h"
 
 #import "components/audio/RTCAudioSession.h"
+#import "components/audio/RTCAudioSessionProxy.h"
 #import "components/audio/RTCAudioSessionConfiguration.h"
 
 @interface RTC_OBJC_TYPE (RTCAudioSession)
@@ -310,7 +311,7 @@ OCMLocation *OCMMakeLocation(id testCase, const char *fileCString, int line){
 - (void)testAudioVolumeDidNotify {
   MockAVAudioSession *mockAVAudioSession = [[MockAVAudioSession alloc] init];
   RTC_OBJC_TYPE(RTCAudioSession) *session =
-      [[RTC_OBJC_TYPE(RTCAudioSession) alloc] initWithAudioSession:mockAVAudioSession];
+      [[RTC_OBJC_TYPE(RTCAudioSession) alloc] initWithAudioSession:[[RTC_OBJC_TYPE(RTCAudioSessionProxy) alloc] initWithAudioSession:(AVAudioSession*)mockAVAudioSession]];
   RTCAudioSessionTestDelegate *delegate =
       [[RTCAudioSessionTestDelegate alloc] init];
   [session addDelegate:delegate];


### PR DESCRIPTION
```swift
import WebRTC

let session: RTCAudioSessionProxy = RTCAudioSession.sharedInstance().session
session.setActiveBlock = { active, options in
     log.info("setActive: \(active), options: \(options)")
     // ignore
     return nil
}
session.setCategoryBlock = { category, options in
     log.info("setCategory: \(category), options: \(options)")
     // TBD
     return nil
}
session.setModeBlock = { mode in
     log.info("setMode: \(mode)")
     // TBD
     return nil
}
…
```
`RTCAudioSessionProxy` provides a way to customize setters at application layer.
So application can take control over audio session management which is critical for CallKit integration.
