### PR TITLE
Add SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+    name: "JitsiWebRTC",
+    platforms: [.iOS(.v12)],
+    products: [
+        .library(
+            name: "WebRTC",
+            targets: ["WebRTC"]),
+    ],
+    dependencies: [],
+    targets: [
+        .binaryTarget(
+            name: "WebRTC",
+            url: "https://github.com/jitsi/webrtc/releases/download/v106.0.0/WebRTC.xcframework.zip",
+            checksum: "f8cfe9bd5190f50080ae21105c5ed385998c9578cc06eb53bfdab91f1482a821"
+        ),
+    ]
+)


### PR DESCRIPTION
Hi,

Thank you for publishing this build!

I would like to request Swift Package Manager support. This means the following:

1. Add a .zip file of the bitcode iOS build to the release (really, SPM does not support tarballs 🙄).
2. Add the included `Package.swift` file.
3. Possibly update the checksum (it is SHA-256).

I tried this out in a separate repository, the checksum below is for the following file: https://github.com/Talk360/WebRTC/releases/download/100.0.0/WebRTC.xcframework-bitcode.zip